### PR TITLE
history cleanup

### DIFF
--- a/NessusClient.py
+++ b/NessusClient.py
@@ -315,10 +315,8 @@ class NessusRestClient:
         r = self.__request(url, method='DELETE')
         #if r.status_code == 200:
             #return r.json()
-        if r.status_code == 500:
+        if r.status_code != 200:
             raise Exception('Scan deletion failed')
-        else:
-            raise Exception('Delete Scan - Unknown Status')
 
     def export_scan(self, scan_id, format, chapters=None):
         ''' requests a report export; returns file_id

--- a/NessusClient.py
+++ b/NessusClient.py
@@ -313,9 +313,9 @@ class NessusRestClient:
         ''' delete a scan by its scan_id '''
         url = self.url + '/scans/' + str(scan_id)
         r = self.__request(url, method='DELETE')
-        if r.status_code == 200:
-            return r.json()
-        elif r.status_code == 500:
+        #if r.status_code == 200:
+            #return r.json()
+        if r.status_code == 500:
             raise Exception('Scan deletion failed')
         else:
             raise Exception('Delete Scan - Unknown Status')


### PR DESCRIPTION
created a couple new methods to cleanup history items for scans. One deletes a single history item, the other allows caller to specify how many history items to keep and it removes all oldest except those. I typically want to remove all but x number of history items from our scanner. If you'd rather have it implemented another way let me know and I'll try.

Oh, and I know almost 0 about python so there may be a better way of doing what I did...
